### PR TITLE
Add individual load energy sensors and integration cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.local/
+AGENTS.local.md
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -11,32 +14,47 @@ __pycache__/
 build/
 develop-eggs/
 dist/
-download/
+downloads/
 eggs/
 .eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
 *.egg-info/
-.installed.cfg
-*.egg
+pip-wheel-metadata/
 
-# Virtual environments
-.venv/
-venv/
-ENV/
 env/
+venv/
+.venv/
+ENV/
 
-# Pytest
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
 .pytest_cache/
 
 # mypy
 .mypy_cache/
 
-# VS Code
+# Pyre
+.pyre/
+
+# Editor directories
 .vscode/
+.idea/
+
+# Misc
+*.pyc
+*.pyo
+*.pyd
+*.egg
+*.egg-info
+__pycache__/
 
 # macOS
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# Savant Energy Agent Guide
+
+This repository is a Home Assistant custom integration for Savant Energy hardware. Keep changes narrow, validate behavior against Home Assistant integration patterns, and prefer fixing the controlling code path over layering workarounds.
+
+## Architecture
+
+- `custom_components/savant_energy/__init__.py` owns config-entry setup, the `SavantEnergyCoordinator`, platform forwarding, and Lovelace resource registration.
+- `custom_components/savant_energy/snapshot_data.py` is the TCP snapshot ingestion path. It connects to the Savant controller, decodes the base64 payload, and returns the JSON used to build entities.
+- `custom_components/savant_energy/sensor.py`, `binary_sensor.py`, `switch.py`, and `button.py` materialize Home Assistant entities from `coordinator.data["snapshot_data"]["presentDemands"]`.
+- `custom_components/savant_energy/utils.py` contains the DMX/OLA integration, address discovery, caches, retry loops, and shared API statistics.
+- `custom_components/savant_energy/scene.py` and `api.py` handle scene storage, execution, REST endpoints, and HA services.
+- `custom_components/savant_energy/savant-energy-scenes-card.js` is the custom frontend surface. Frontend regressions often come from REST shape changes or static resource registration in `__init__.py`.
+
+## Development Rules
+
+- Preserve stable Home Assistant identifiers. Device identifiers and entity `unique_id` values are based on the Savant `uid`; do not churn them unless migration is intentional.
+- When changing entity behavior, inspect the coordinator data shape first. Most platform bugs trace back to missing or malformed `presentDemands` data rather than the entity class itself.
+- Treat `utils.py` module globals as shared state. Cache changes, retry logic, or stat tracking can affect every integration instance.
+- Keep scene changes compatible with both REST callers and service calls. The frontend card depends on the existing scene API contract.
+- Prefer config-entry option fallbacks in the existing style: `entry.options.get(key, entry.data.get(key, default))`.
+- When a live Home Assistant instance is available, use the workspace `home-assistant` MCP server before adding temporary debug code. Prefer reading current states, services, traces, logs, and entity metadata through MCP first.
+- If the MCP server is relevant to the task, inspect `tools/ha-mcp-wrapper.ps1` and `.local/hass.env` before guessing at connection details.
+
+## Debugging Workflow
+
+- If entities are missing, inspect logs around coordinator refresh in `custom_components/savant_energy/__init__.py` and snapshot parsing in `custom_components/savant_energy/snapshot_data.py`.
+- If DMX addresses stay unavailable, inspect the RDM discovery and UID lookup path in `custom_components/savant_energy/utils.py` before changing sensors or switches.
+- If switch control fails, trace the DMX address source first. `switch.py` depends on the DMX address sensor state and then sends a full DMX payload.
+- If scene behavior breaks, review both `custom_components/savant_energy/scene.py` and `custom_components/savant_energy/api.py`. Scene execution, storage normalization, REST responses, and service handlers are split across those files.
+- If the custom card breaks, verify the static resource registration path and API responses before changing the JavaScript.
+- If a live Home Assistant instance is available, prefer the workspace `home-assistant` MCP server for state inspection, service discovery, automation tracing, and log-oriented investigation before adding temporary debug code.
+- Use `.local/hass-debug.ps1` only when the MCP server is unavailable or when you need a direct REST comparison.
+
+## Change Strategy
+
+- Make small edits and validate immediately.
+- Prefer focused checks over whole-repo churn.
+- Do not rewrite logging style or comments across unrelated files.
+- Keep documentation in sync when changing setup, API shape, or developer workflow.
+
+## Local-Only Files
+
+- `.local/` is ignored and intended for machine-specific scripts, env files, and scratch notes.
+- `AGENTS.local.md` is ignored and reserved for private instructions, tokens, or environment-specific debugging notes that should not be committed.
+
+## Useful Local Setup
+
+- Workspace MCP configuration lives in `.vscode/mcp.json`.
+- The workspace MCP config launches `ha-mcp` through `tools/ha-mcp-wrapper.ps1`, which loads `.local/hass.env` and starts the upstream stdio server with the expected `HOMEASSISTANT_URL` and `HOMEASSISTANT_TOKEN` environment variables.
+- Local Home Assistant connection details and helper scripts live under `.local/`.
+- Use `.local/hass-debug.ps1` for quick API and error-log pulls when an MCP resource or tool is not enough.
+- The wrapper intentionally uses `uvx --python 3.13 --refresh ha-mcp@latest`; keep the wrapper aligned with upstream `ha-mcp` documentation if the server contract changes.
+
+## MCP Usage Expectations
+
+- Prefer MCP when you need current Home Assistant state, service lists, config entries, traces, logs, or entity metadata.
+- Prefer the repo wrapper instead of hand-crafting alternate local launch commands.
+- If file editing or config management tools are needed from MCP, verify the Home Assistant-side `ha_mcp_tools` component and the required feature flags are installed and enabled.
+- If you update the wrapper or MCP configuration, update [docs/development.md](docs/development.md) at the same time.
+- The upstream `homeassistant-ai/ha-mcp` repository is the source of truth for tool names and command shapes. For logs and history, prefer `ha_get_logs` and `ha_get_history`; for execution tracing use `ha_get_automation_traces`; for service discovery use `ha_list_services`; for integration metadata use `ha_get_integration`.
+- `ha_list_files` only lists `www/`, `themes/`, and `custom_templates/`; it does not enumerate a generic logs folder.
+- For log-file inspection, prefer `ha_get_logs(source="system"|"error_log"|"supervisor")` first and `ha_read_file(path="home-assistant.log", tail_lines=...)` only when the file-access component is installed.
+
+## Home Assistant MCP Guidance
+
+- Keep `.local/hass.env` populated with the Home Assistant base URL and long-lived token before relying on the MCP server.
+- Prefer MCP for runtime investigation that needs current HA state, integrations, services, automations, traces, or filesystem-backed HA MCP tools.
+- Fall back to `.local/hass-debug.ps1` when the MCP server is unavailable or you need a direct REST response for comparison.
+- If `ha-mcp` file tools are needed, ensure the Home Assistant side also has the `ha_mcp_tools` custom component and the required feature flags enabled.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Welcome to the **Savant Energy** integration for Home Assistant! This project br
 ## 🚀 Features
 - **Automatic device discovery** from your Savant system
 - **Power and voltage sensors** for each relay
+- **Per-load cumulative energy sensors** in `kWh` for use with the Home Assistant Energy dashboard
 - **Relay (breaker) switch control** with configurable cooldown
 - **Relay Binary sensors** for relay status
 - **All Loads On Button** to quickly turn all loads on
@@ -33,6 +34,7 @@ Once installed and configured, the integration will automatically create entitie
 
 ### Entity Breakdown
 - **Power Sensor (`sensor.<device>_power`)**: Shows the real-time power usage (Watts) for each relay.
+- **Energy Sensor (`sensor.<device>_energy`)**: Tracks cumulative energy usage (kWh) for each relay and can be added to Home Assistant's Energy dashboard under individual devices.
 - **Voltage Sensor (`sensor.<device>_voltage`)**: Displays the current voltage (Volts) for each relay.
 - **Breaker Switch (`switch.<device>_breaker`)**: Lets you turn the relay on/off. Includes a configurable cooldown (default: 30 seconds) to prevent rapid toggling and protect your hardware.
 - **Relay Status Binary Sensor (`binary_sensor.<device>_relay_status`)**: Indicates if the relay is currently ON or OFF.
@@ -127,6 +129,11 @@ We love contributions! Please:
 - Open issues for bugs or feature requests
 - Submit pull requests with clear descriptions
 - Follow the code style and add docstrings/comments
+
+This project uses AI coding agents during development, but all code changes are reviewed and tested before release.
+
+## 📘 Development
+See [docs/development.md](docs/development.md) for the local Home Assistant MCP workflow, wrapper behavior, and development expectations.
 
 ## 📚 File Structure
 - `__init__.py`: Integration setup and coordinator logic

--- a/custom_components/savant_energy/button.py
+++ b/custom_components/savant_energy/button.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback  # type: i
 from homeassistant.helpers.event import async_track_time_interval  # type: ignore
 
 from .const import DOMAIN, MANUFACTURER, DEFAULT_OLA_PORT, CONF_DMX_TESTING_MODE
-from .utils import async_set_dmx_values, get_dmx_api_stats
+from .utils import async_set_dmx_values, get_dmx_api_stats, get_dmx_address_from_state
 from .scene import SavantSceneStorage, SavantSceneManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -73,27 +73,25 @@ class SavantSceneButton(ButtonEntity):
             return
         relay_states = scene.get("relay_states", {})
         dmx_values = {}
-        # For each breaker in relay_states, look up its DMX address sensor
         for breaker_entity_id, is_on in relay_states.items():
-            # The DMX address sensor is expected to be sensor.<breaker_entity_id>_dmx_address
-            if breaker_entity_id.startswith("switch."):
-                base = breaker_entity_id[len("switch."):]
-            else:
-                base = breaker_entity_id
-            dmx_sensor_id = f"sensor.{base}_dmx_address"
-            state = self._hass.states.get(dmx_sensor_id)
-            if state and state.state not in ("unknown", "unavailable"):
-                try:
-                    dmx_address = int(state.state)
-                    dmx_values[dmx_address] = "255" if is_on else "0"
-                except (ValueError, TypeError):
-                    _LOGGER.debug(f"Invalid DMX address value in sensor {dmx_sensor_id}: {state.state}")
-                    fallback_addr = len(dmx_values) + 1
-                    dmx_values[fallback_addr] = "255" if is_on else "0"
-            else:
-                _LOGGER.debug(f"DMX address sensor not found or unavailable for {dmx_sensor_id}, using scene state value")
-                fallback_addr = len(dmx_values) + 1
-                dmx_values[fallback_addr] = "255" if is_on else "0"
+            breaker_state = self._hass.states.get(breaker_entity_id)
+            device_uid = breaker_state.attributes.get("uid") if breaker_state else None
+            if not device_uid:
+                _LOGGER.warning(
+                    "Skipping scene member %s because its device UID is unavailable",
+                    breaker_entity_id,
+                )
+                continue
+
+            dmx_address = get_dmx_address_from_state(self._hass, device_uid)
+            if dmx_address is None:
+                _LOGGER.warning(
+                    "Skipping scene member %s because its DMX address is unavailable",
+                    breaker_entity_id,
+                )
+                continue
+
+            dmx_values[dmx_address] = "255" if is_on else "0"
 
         if not dmx_values:
             _LOGGER.warning(

--- a/custom_components/savant_energy/dmx_address_sensor.py
+++ b/custom_components/savant_energy/dmx_address_sensor.py
@@ -48,6 +48,7 @@ class DMXAddressSensor(CoordinatorEntity, SensorEntity):
             manufacturer=MANUFACTURER,
             model=get_device_model(device.get("capacity", 0)),
         )
+        self._attr_extra_state_attributes = {"uid": device["uid"], "dmx_uid": dmx_uid}
         self._slug_name = slugify(device["name"])
 
     @property

--- a/custom_components/savant_energy/power_device_sensor.py
+++ b/custom_components/savant_energy/power_device_sensor.py
@@ -1,13 +1,12 @@
 """Energy Device Sensor for Savant Energy.
-Provides power and voltage sensor entities for each relay device.
-
-All classes and functions are now documented for clarity and open source maintainability.
+Provides power, voltage, and cumulative energy sensor entities for each relay device.
 """
 
 import logging
-from typing import Any, Optional
+import time
 
 from homeassistant.components.sensor import (  # type: ignore
+    RestoreSensor,
     SensorEntity,
     SensorDeviceClass,
     SensorStateClass,
@@ -177,3 +176,124 @@ class EnergyDeviceSensor(CoordinatorEntity, SensorEntity):
             manufacturer=MANUFACTURER,
             model=get_device_model(self._device.get("capacity", 0)),
         )
+
+
+class IndividualLoadEnergySensor(CoordinatorEntity, RestoreSensor):
+    """Cumulative energy sensor derived from the per-load power reading."""
+
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_icon = "mdi:lightning-bolt-circle"
+    _attr_native_unit_of_measurement = "kWh"
+    _attr_state_class = SensorStateClass.TOTAL
+    _attr_suggested_display_precision = 3
+
+    def __init__(self, coordinator, device, unique_id, dmx_uid):
+        """Initialize the cumulative energy sensor."""
+        super().__init__(coordinator)
+        self._device = device
+        self._dmx_uid = dmx_uid
+        self._attr_name = f"{device['name']} Energy"
+        self._attr_unique_id = unique_id
+        self._energy_kwh = 0.0
+        self._last_power_watts = None
+        self._last_sample_time = None
+
+    @property
+    def _current_device_name(self):
+        """Fetch the current device name by UID from coordinator data."""
+        snapshot_data = self.coordinator.data.get("snapshot_data", {})
+        if snapshot_data and "presentDemands" in snapshot_data:
+            for device in snapshot_data["presentDemands"]:
+                if device["uid"] == self._device["uid"]:
+                    return device["name"]
+        return self._device["name"]
+
+    @property
+    def name(self):
+        """Return the sensor name using the latest device name."""
+        return f"{self._current_device_name} Energy"
+
+    @property
+    def native_value(self) -> float:
+        """Return the cumulative energy in kWh."""
+        return round(self._energy_kwh, 6)
+
+    @property
+    def available(self) -> bool:
+        """Return True if the source power reading is currently available."""
+        return self._get_current_power_watts() is not None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return dynamic device info with the current device name."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, str(self._device["uid"]))},
+            name=self._current_device_name,
+            serial_number=self._dmx_uid,
+            manufacturer=MANUFACTURER,
+            model=get_device_model(self._device.get("capacity", 0)),
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the accumulated energy and initialize the integration baseline."""
+        await super().async_added_to_hass()
+
+        last_sensor_data = await self.async_get_last_sensor_data()
+        if last_sensor_data is not None and last_sensor_data.native_value is not None:
+            try:
+                self._energy_kwh = max(float(last_sensor_data.native_value), 0.0)
+            except (TypeError, ValueError):
+                _LOGGER.warning(
+                    "Ignoring invalid restored energy value %s for device %s",
+                    last_sensor_data.native_value,
+                    self._device["uid"],
+                )
+
+        self._last_power_watts = self._get_current_power_watts()
+        if self._last_power_watts is not None:
+            self._last_sample_time = time.monotonic()
+
+    def _handle_coordinator_update(self) -> None:
+        """Integrate the latest power reading into a cumulative energy total."""
+        current_power_watts = self._get_current_power_watts()
+        now = time.monotonic()
+
+        if (
+            current_power_watts is not None
+            and self._last_power_watts is not None
+            and self._last_sample_time is not None
+        ):
+            elapsed_hours = (now - self._last_sample_time) / 3600.0
+            if elapsed_hours > 0:
+                average_power_watts = (
+                    self._last_power_watts + current_power_watts
+                ) / 2.0
+                self._energy_kwh += (average_power_watts * elapsed_hours) / 1000.0
+
+        self._last_power_watts = current_power_watts
+        self._last_sample_time = now if current_power_watts is not None else None
+        self.async_write_ha_state()
+
+    def _get_current_power_watts(self) -> float | None:
+        """Return the current device power reading in watts."""
+        snapshot_data = self.coordinator.data.get("snapshot_data", {})
+        if snapshot_data and "presentDemands" in snapshot_data:
+            for device in snapshot_data["presentDemands"]:
+                if device["uid"] != self._device["uid"]:
+                    continue
+
+                value = device.get("power")
+                if value is None:
+                    return None
+
+                try:
+                    return max(float(value) * 1000.0, 0.0)
+                except (ValueError, TypeError):
+                    _LOGGER.error(
+                        "Invalid power value %s for energy sensor on device %s",
+                        value,
+                        device["uid"],
+                    )
+                    return None
+
+        return None

--- a/custom_components/savant_energy/scene.py
+++ b/custom_components/savant_energy/scene.py
@@ -25,7 +25,7 @@ from .api import register_scene_services  # type: ignore
 from homeassistant.exceptions import HomeAssistantError  # type: ignore
 
 from .const import DOMAIN, MANUFACTURER, DEFAULT_OLA_PORT, CONF_DMX_TESTING_MODE
-from .utils import async_set_dmx_values, slugify
+from .utils import async_set_dmx_values, get_dmx_address_from_state, slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -552,33 +552,32 @@ class SavantSceneManager:
         # Get DMX addresses and values
         dmx_values = {}
 
-        # First get all DMX address sensors
-        all_entity_ids = self.hass.states.async_entity_ids("sensor")
-        dmx_address_sensors = [
-            entity_id
-            for entity_id in all_entity_ids
-            if entity_id.endswith("_dmx_address")
-        ]
-
-        # For each DMX address sensor, check if it's in our scene and set the value
-        for entity_id in dmx_address_sensors:
-            state = self.hass.states.get(entity_id)
-            if not state or state.state in ("unknown", "unavailable"):
+        for breaker_entity_id, is_on in relay_states.items():
+            breaker_state = self.hass.states.get(breaker_entity_id)
+            if not breaker_state:
+                _LOGGER.warning(
+                    "Skipping scene member %s because the switch entity is unavailable",
+                    breaker_entity_id,
+                )
                 continue
 
-            try:
-                dmx_address = int(state.state)
-            except Exception:
+            device_uid = breaker_state.attributes.get("uid")
+            if not device_uid:
+                _LOGGER.warning(
+                    "Skipping scene member %s because its device UID is unavailable",
+                    breaker_entity_id,
+                )
                 continue
 
-            # Use the entity_id (breaker id) as the key for relay_states lookup
-            breaker_id = entity_id
-            # If breaker_id is in relay_states, use its value, else ON (255)
-            value = (
-                255
-                if breaker_id not in relay_states
-                else (255 if relay_states[breaker_id] else 0)
-            )
+            dmx_address = get_dmx_address_from_state(self.hass, device_uid)
+            if dmx_address is None:
+                _LOGGER.warning(
+                    "Skipping scene member %s because its DMX address is unavailable",
+                    breaker_entity_id,
+                )
+                continue
+
+            value = 255 if is_on else 0
             dmx_values[dmx_address] = str(value)
 
         if not dmx_values:

--- a/custom_components/savant_energy/sensor.py
+++ b/custom_components/savant_energy/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity import DeviceInfo  # type: ignore
 
 from .const import DOMAIN, MANUFACTURER
 from .models import get_device_model
-from .power_device_sensor import EnergyDeviceSensor
+from .power_device_sensor import EnergyDeviceSensor, IndividualLoadEnergySensor
 from .dmx_address_sensor import DMXAddressSensor
 from .utils import calculate_dmx_uid
 
@@ -68,6 +68,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 )
                 entities.append(power_sensor)
                 power_sensors.append(power_sensor)
+
+                # Create cumulative energy sensor for the Energy dashboard
+                entities.append(
+                    IndividualLoadEnergySensor(
+                        coordinator,
+                        device,
+                        f"SavantEnergy_{uid}_energy",
+                        dmx_uid,
+                    )
+                )
 
                 # Create voltage sensor
                 entities.append(

--- a/custom_components/savant_energy/switch.py
+++ b/custom_components/savant_energy/switch.py
@@ -26,13 +26,9 @@ from .const import (
     DEFAULT_PENDING_CONFIRM_MULTIPLIER,
 )
 from .models import get_device_model
-from .utils import calculate_dmx_uid, async_set_dmx_values, async_get_dmx_address, slugify
+from .utils import calculate_dmx_uid, async_set_dmx_values, get_dmx_address_from_state
 
 _LOGGER = logging.getLogger(__name__)
-
-_last_command_time = 0.0
-PENDING_CONFIRM_MULTIPLIER: int = 3  # Number of coordinator update intervals to wait before timing out
-
 
 async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entities):
     """
@@ -89,6 +85,7 @@ class EnergyDeviceSwitch(CoordinatorEntity, SwitchEntity):
             ),
             serial_number=self._dmx_uid,
         )
+        self._attr_extra_state_attributes = {"uid": device["uid"], "dmx_uid": self._dmx_uid}
         self._attr_is_on = self._get_relay_status_state()
         self._last_commanded_state = self._attr_is_on
         # Pending confirmation state after a user-initiated command
@@ -96,6 +93,8 @@ class EnergyDeviceSwitch(CoordinatorEntity, SwitchEntity):
         self._pending_confirm_target: bool | None = None
         self._pending_confirm_task: asyncio.Task | None = None
         self._pending_confirm_expires: float | None = None
+        self._last_command_time = 0.0
+        self._last_command_time = 0.0
         self.async_on_remove(
             self.coordinator.async_add_listener(self._handle_coordinator_update)
         )
@@ -121,9 +120,13 @@ class EnergyDeviceSwitch(CoordinatorEntity, SwitchEntity):
         """
         Get the state of the switch based on the relay status sensor, or None if unknown.
         """
+        return self._get_relay_status_state_for_uid(self._device["uid"])
+
+    def _get_relay_status_state_for_uid(self, device_uid: str) -> bool | None:
+        """Get the relay state for a device UID from the relay status sensor."""
         for binary_sensor in self._hass.states.async_all("binary_sensor"):
             if (
-                binary_sensor.attributes.get("uid") == self._device["uid"]
+                binary_sensor.attributes.get("uid") == device_uid
             ):
                 if binary_sensor.state.lower() == "on":
                     return True
@@ -132,27 +135,20 @@ class EnergyDeviceSwitch(CoordinatorEntity, SwitchEntity):
                 break
         return None
 
-    async def _get_dmx_address_from_sensor(self) -> int | None:
+    async def _get_dmx_address_from_sensor(self, device_uid: str, device_name: str) -> int | None:
         """
         Try to get the DMX address from the sensor entity for this device.
         """
-        dmx_address_entity_id = f"sensor.{slugify(self._current_device_name)}_dmx_address"
-        alternative_entity_id = f"sensor.savant_energy_{self._device['uid']}_dmx_address"
-        state = self._hass.states.get(dmx_address_entity_id)
-        if not state or state.state in ('unknown', 'unavailable'):
-            state = self._hass.states.get(alternative_entity_id)
-        if state and state.state not in ('unknown', 'unavailable'):
-            try:
-                return int(state.state)
-            except (ValueError, TypeError):
-                _LOGGER.warning(f"Invalid DMX address in sensor {state.entity_id}: {state.state}")
-        return None    
+        return get_dmx_address_from_state(self._hass, device_uid, device_name)
 
     async def _fetch_dmx_address(self) -> int | None:
         """
         Fetch DMX address from sensor only.
         """
-        address = await self._get_dmx_address_from_sensor()
+        address = await self._get_dmx_address_from_sensor(
+            self._device["uid"],
+            self._current_device_name,
+        )
         if address is not None:
             return address
         _LOGGER.warning(f"No DMX address found in sensor for {self.name}")
@@ -160,47 +156,33 @@ class EnergyDeviceSwitch(CoordinatorEntity, SwitchEntity):
 
     async def _get_all_device_dmx_states(self, target_dmx_address=None, target_value=None):
         """
-        Build a dict of {dmx_address: value} for all devices using only DMX Address and Relay Status sensors.
+        Build a dict of {dmx_address: value} for all devices using the coordinator device map and UID-based sensors.
         """
         dmx_states = {}
         max_address = 0
-        dmx_address_entities = [entity for entity in self._hass.states.async_all("sensor") if entity.entity_id.endswith("_dmx_address")]
 
-        for dmx_address_entity in dmx_address_entities:
-            if dmx_address_entity.state in ("unknown", "unavailable") or not dmx_address_entity.state:
+        snapshot_data = self.coordinator.data.get("snapshot_data", {}) if self.coordinator.data else {}
+        devices = snapshot_data.get("presentDemands", []) if isinstance(snapshot_data, dict) else []
+
+        for device in devices:
+            device_uid = device.get("uid")
+            device_name = device.get("name", device_uid)
+            if not device_uid:
                 continue
-            try:
-                dmx_address = int(dmx_address_entity.state)
-            except (ValueError, TypeError):
-                _LOGGER.warning(f"Invalid DMX address in sensor {dmx_address_entity.entity_id}: {dmx_address_entity.state}")
+
+            dmx_address = await self._get_dmx_address_from_sensor(device_uid, device_name)
+            if dmx_address is None:
+                _LOGGER.debug("Skipping %s because its DMX address is unavailable", device_name)
                 continue
 
-            entity_id = dmx_address_entity.entity_id
-            device_name = None
-            sensor_state = self._hass.states.get(entity_id)
-            if sensor_state and sensor_state.attributes.get("friendly_name"):
-                device_name = sensor_state.attributes.get("friendly_name").replace(" DMX Address", "")
-            if not device_name:
-                entity_name = entity_id.split(".", 1)[1].replace("_dmx_address", "")
-                device_name = entity_name.replace("_", " ").title()
+            relay_state = self._get_relay_status_state_for_uid(device_uid)
+            if relay_state is None and "percentCommanded" in device:
+                relay_state = device.get("percentCommanded") == 100
+            if relay_state is None:
+                _LOGGER.debug("Skipping %s because its relay state is unavailable", device_name)
+                continue
 
-            relay_found = False
-            relay_status_state = None
-            for binary_sensor in self._hass.states.async_all("binary_sensor"):
-                if binary_sensor.attributes.get("friendly_name") and f"{device_name} Relay Status" == binary_sensor.attributes.get("friendly_name"):
-                    relay_status_state = binary_sensor
-                    relay_found = True
-                    break
-
-            value = "255"
-            if relay_found and relay_status_state and relay_status_state.state not in ("unknown", "unavailable"):
-                if relay_status_state.state.lower() == "on":
-                    value = "255"
-                elif relay_status_state.state.lower() == "off":
-                    value = "0"
-                _LOGGER.debug(f"Found relay status for {device_name}: {relay_status_state.state} (using value {value})")
-            else:
-                _LOGGER.debug(f"No relay status found for {device_name}, defaulting to ON")
+            value = "255" if relay_state else "0"
 
             dmx_states[dmx_address] = value
             if dmx_address > max_address:
@@ -265,10 +247,9 @@ class EnergyDeviceSwitch(CoordinatorEntity, SwitchEntity):
         Turn the switch on.
         Implements cooldown logic to prevent rapid toggling.
         """
-        global _last_command_time
         now = time.monotonic()
-        if now - _last_command_time < self._cooldown:
-            time_left = math.ceil(self._cooldown - (now - _last_command_time))
+        if now - self._last_command_time < self._cooldown:
+            time_left = math.ceil(self._cooldown - (now - self._last_command_time))
             _LOGGER.debug("Cooldown active, ignoring turn_on command")
             await self._hass.services.async_call(
                 "persistent_notification",
@@ -281,11 +262,11 @@ class EnergyDeviceSwitch(CoordinatorEntity, SwitchEntity):
             )
             return
         if not self.is_on:
-            _last_command_time = now
             dmx_address = await self._fetch_dmx_address()
             if dmx_address is None:
                 _LOGGER.warning(f"Cannot turn on {self.name}: DMX address unknown")
                 return
+            self._last_command_time = now
             _LOGGER.info(f"Turning ON {self.name} at DMX address {dmx_address}")
             result = await self._send_full_dmx_command(dmx_address, "255")
             if result and result.get("success"):
@@ -302,10 +283,9 @@ class EnergyDeviceSwitch(CoordinatorEntity, SwitchEntity):
         Turn the switch off.
         Implements cooldown logic to prevent rapid toggling.
         """
-        global _last_command_time
         now = time.monotonic()
-        if now - _last_command_time < self._cooldown:
-            time_left = math.ceil(self._cooldown - (now - _last_command_time))
+        if now - self._last_command_time < self._cooldown:
+            time_left = math.ceil(self._cooldown - (now - self._last_command_time))
             _LOGGER.debug("Cooldown active, ignoring turn_off command")
             await self._hass.services.async_call(
                 "persistent_notification",
@@ -318,11 +298,11 @@ class EnergyDeviceSwitch(CoordinatorEntity, SwitchEntity):
             )
             return
         if self.is_on:
-            _last_command_time = now
             dmx_address = await self._fetch_dmx_address()
             if dmx_address is None:
                 _LOGGER.warning(f"Cannot turn off {self.name}: DMX address unknown")
                 return
+            self._last_command_time = now
             _LOGGER.info(f"Turning OFF {self.name} at DMX address {dmx_address}")
             result = await self._send_full_dmx_command(dmx_address, "0")
             if result and result.get("success"):

--- a/custom_components/savant_energy/utils.py
+++ b/custom_components/savant_energy/utils.py
@@ -301,6 +301,53 @@ def slugify(name: str) -> str:
     return name
 
 
+def get_dmx_address_from_state(
+    hass: Any,
+    device_uid: str,
+    device_name: Optional[str] = None,
+) -> Optional[int]:
+    """Resolve a DMX address from Home Assistant state using the stable device UID."""
+    if not hass or not device_uid:
+        return None
+
+    for sensor_state in hass.states.async_all("sensor"):
+        if not sensor_state.entity_id.endswith("_dmx_address"):
+            continue
+        if sensor_state.attributes.get("uid") != device_uid:
+            continue
+        if sensor_state.state in ("unknown", "unavailable"):
+            return None
+        try:
+            return int(sensor_state.state)
+        except (ValueError, TypeError):
+            _LOGGER.warning(
+                "Invalid DMX address in sensor %s: %s",
+                sensor_state.entity_id,
+                sensor_state.state,
+            )
+            return None
+
+    legacy_entity_ids = [f"sensor.savant_energy_{device_uid}_dmx_address"]
+    if device_name:
+        legacy_entity_ids.insert(0, f"sensor.{slugify(device_name)}_dmx_address")
+
+    for entity_id in legacy_entity_ids:
+        state = hass.states.get(entity_id)
+        if not state or state.state in ("unknown", "unavailable"):
+            continue
+        try:
+            return int(state.state)
+        except (ValueError, TypeError):
+            _LOGGER.warning(
+                "Invalid DMX address in sensor %s: %s",
+                entity_id,
+                state.state,
+            )
+            return None
+
+    return None
+
+
 async def async_get_dmx_address(
     ip_address: str,
     ola_port: int,
@@ -596,6 +643,60 @@ async def _execute_curl_command(cmd: str) -> tuple[int, str, str]:
     return returncode, stdout.decode(), stderr.decode()
 
 
+def _normalize_dmx_value(value: Any, default: str = "255") -> str:
+    """Normalize a DMX value to a stringified integer between 0 and 255."""
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "on":
+            return "255"
+        if normalized == "off":
+            return "0"
+    try:
+        numeric_value = int(value)
+    except (TypeError, ValueError):
+        return default
+    return str(max(0, min(255, numeric_value)))
+
+
+async def _async_get_current_dmx_values(
+    ip_address: str,
+    ola_port: int,
+    max_channel: int,
+) -> list[str]:
+    """Fetch the current DMX universe and return normalized values up to max_channel."""
+    if not ip_address or not ola_port or max_channel <= 0:
+        return []
+
+    url = f"http://{ip_address}:{ola_port}/get_dmx?u=1"
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            timeout_config = aiohttp.ClientTimeout(total=10.0)
+            async with session.get(url, timeout=timeout_config) as response:
+                if response.status != 200:
+                    _LOGGER.debug(
+                        "Unable to fetch current DMX values before set; status=%s response=%s",
+                        response.status,
+                        await response.text(),
+                    )
+                    return []
+
+                payload = json.loads(await response.text())
+    except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError) as err:
+        _LOGGER.debug("Unable to fetch current DMX values before set: %s", err)
+        return []
+    except Exception as err:
+        _LOGGER.debug("Unexpected error fetching current DMX values before set: %s", err)
+        return []
+
+    dmx_values = payload.get("dmx")
+    if not isinstance(dmx_values, list):
+        _LOGGER.debug("Current DMX payload did not include a valid dmx list: %s", payload)
+        return []
+
+    return [_normalize_dmx_value(value) for value in dmx_values[:max_channel]]
+
+
 async def async_set_dmx_values(ip_address: str, channel_values: Dict[int, str], ola_port: int = 9090, testing_mode: bool = False) -> Dict[str, Any]:
     """
     Set DMX values for channels.
@@ -612,15 +713,24 @@ async def async_set_dmx_values(ip_address: str, channel_values: Dict[int, str], 
     
     try:
         max_channel = max(channel_values.keys()) if channel_values else 0
+        if max_channel == 0:
+            _LOGGER.warning("No DMX channel values were provided")
+            return {"success": False, "status": None, "text": None, "json": None, "error": "No channel values provided"}
 
         value_array = ["0"] * max_channel
 
+        if not testing_mode:
+            current_values = await _async_get_current_dmx_values(
+                ip_address,
+                ola_port,
+                max_channel,
+            )
+            for index, current_value in enumerate(current_values):
+                value_array[index] = current_value
+        
         for channel, value in channel_values.items():
             if 1 <= channel <= max_channel:
-                if str(value) == "255" or str(value).lower() == "on" or str(value) == "1":
-                    value_array[channel - 1] = "255"
-                else:
-                    value_array[channel - 1] = "0"
+                value_array[channel - 1] = _normalize_dmx_value(value, default="0")
 
         data_param = ",".join(value_array)
 
@@ -675,7 +785,7 @@ async def async_set_dmx_values(ip_address: str, channel_values: Dict[int, str], 
         _dmx_api_stats["failure_count"] += 1
         _dmx_api_stats["success_rate"] = ((_dmx_api_stats["request_count"] - _dmx_api_stats["failure_count"]) / 
                                         _dmx_api_stats["request_count"]) * 100.0
-        return False
+        return {"success": False, "status": None, "text": None, "json": None, "error": str(e)}
 
 
 def is_dmx_api_available() -> bool:

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,94 @@
+# Development Guide
+
+This repository uses a local Home Assistant MCP setup for day-to-day debugging and code review support. The goal is to inspect the live system first, then change the integration code only when the evidence points there.
+
+## MCP Setup
+
+The workspace MCP server is defined in [.vscode/mcp.json](../.vscode/mcp.json) and launches [tools/ha-mcp-wrapper.ps1](../tools/ha-mcp-wrapper.ps1).
+
+The wrapper does three things:
+
+1. Loads [.local/hass.env](../.local/hass.env) for machine-specific values.
+2. Exports `HOMEASSISTANT_URL` and `HOMEASSISTANT_TOKEN` for the upstream `ha-mcp` server.
+3. Starts `uvx --python 3.13 --refresh ha-mcp@latest` so VS Code can connect to Home Assistant through MCP.
+
+Recommended `.local/hass.env` values:
+
+```env
+HOMEASSISTANT_URL=http://homeassistant.local:8123
+HOMEASSISTANT_TOKEN=your_long_lived_access_token
+FASTMCP_SHOW_SERVER_BANNER=false
+```
+
+Optional aliases for the direct REST helper:
+
+```env
+HASS_BASE_URL=http://homeassistant.local:8123
+HASS_TOKEN=your_long_lived_access_token
+```
+
+## How To Use It
+
+Use the MCP server first when you need current state from the Home Assistant instance.
+
+Good MCP questions for this repo:
+
+- What entities were created for the Savant integration?
+- What state or attributes do the breaker switches and DMX sensors currently have?
+- What services, traces, or logs explain why a scene or switch action failed?
+- What config entry options are active for the integration?
+
+When the MCP server is not available, use [.local/hass-debug.ps1](../.local/hass-debug.ps1) for direct REST checks against Home Assistant.
+
+## MCP Quick Reference
+
+The upstream tool names and behavior come from the `homeassistant-ai/ha-mcp` repository. For the latest authoritative list, check the upstream README and tool files in that repo before inventing new command names.
+
+Common read-only tools that are useful for this integration:
+
+- `ha_get_logs(source="logbook"|"system"|"error_log"|"supervisor", limit=?, search=?, hours_back=?, entity_id=?, end_time=?, offset=?, compact=?, level=?, slug=?)`
+- `ha_get_history(entity_ids, source="history"|"statistics", start_time=?, end_time=?, limit=?, offset=?, minimal_response=?, significant_changes_only=?, period=?, statistic_types=?)`
+- `ha_get_automation_traces(automation_id, run_id=?, limit=?, detailed=?)`
+- `ha_get_integration(entry_id=?, query=?, domain=?, exact_match=?)`
+- `ha_list_services(domain=?, query=?, limit=?, offset=?, detail_level=?)`
+- `ha_get_state(entity_id?)` and `ha_search_entities(query=?, domain_filter=?, area_filter=?)` for state/entity lookups when available in the connected MCP server.
+
+For Home Assistant add-on, HACS, and helper/config inspection workflows, the upstream repository also documents tools such as `ha_get_addon`, `ha_hacs_repository_info`, `ha_get_zone`, `ha_get_blueprint`, and `ha_config_get_*` helpers.
+
+### Log Access Rules
+
+- Use `ha_get_logs(source="system")` for structured Home Assistant system logs when you need recent warnings or errors.
+- Use `ha_get_logs(source="error_log")` for the raw Home Assistant error log.
+- Use `ha_get_logs(source="supervisor", slug="core_...")` for add-on container logs when a specific add-on is involved.
+- If the `ha_mcp_tools` component is installed and the `HAMCP_ENABLE_FILESYSTEM_TOOLS=true` flag is enabled, you can read `home-assistant.log` with `ha_read_file(path="home-assistant.log", tail_lines=1000)`.
+- `ha_list_files` does not browse a generic logs folder. It only lists the allowed config subdirectories (`www/`, `themes/`, `custom_templates/`).
+- File access tools only work when both the `ha_mcp_tools` component and the required feature flags are present.
+- For this repo, the first log checks should usually be `ha_get_logs(source="system", search="Savant")` and `ha_get_logs(source="error_log", search="Savant")`; if the component is installed, follow up with `ha_read_file(path="home-assistant.log", tail_lines=200)`.
+
+## Wrapper Notes
+
+- The wrapper is intentionally thin and should stay aligned with upstream `ha-mcp` expectations.
+- Keep `HOMEASSISTANT_URL` and `HOMEASSISTANT_TOKEN` in `.local/hass.env`; do not hardcode them in tracked files.
+- If the upstream server changes its startup contract, update the wrapper first, then adjust `.vscode/mcp.json` and this document.
+
+## Development Workflow
+
+1. Inspect live Home Assistant state or logs through MCP.
+2. Trace the behavior back to the controlling code path in `custom_components/savant_energy/`.
+3. Make the smallest edit that addresses the cause.
+4. Validate immediately with the narrowest useful check.
+
+## Troubleshooting
+
+- If MCP does not start, verify `uvx` is on PATH and `.local/hass.env` exists.
+- If MCP starts but returns no useful data, confirm the Home Assistant URL and token are valid.
+- If file or YAML editing tools are needed through MCP, make sure the Home Assistant-side `ha_mcp_tools` component and feature flags are enabled.
+
+## Repository Focus
+
+The main surfaces to understand before changing code are:
+
+- `custom_components/savant_energy/__init__.py` for setup and coordinator flow.
+- `custom_components/savant_energy/snapshot_data.py` for Savant snapshot parsing.
+- `custom_components/savant_energy/utils.py` for DMX, OLA, cache, and retry behavior.
+- `custom_components/savant_energy/scene.py` and `custom_components/savant_energy/api.py` for scene management.

--- a/tools/ha-mcp-wrapper.ps1
+++ b/tools/ha-mcp-wrapper.ps1
@@ -1,0 +1,59 @@
+param(
+    [string]$EnvFile = ".local/hass.env"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Import-EnvFile {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        throw "Environment file not found at '$Path'. Copy .local/hass.env.example to .local/hass.env and fill in your Home Assistant values."
+    }
+
+    Get-Content $Path | ForEach-Object {
+        $line = $_.Trim()
+        if (-not $line -or $line.StartsWith('#')) {
+            return
+        }
+
+        $parts = $line.Split('=', 2)
+        if ($parts.Count -eq 2) {
+            [System.Environment]::SetEnvironmentVariable($parts[0], $parts[1])
+        }
+    }
+}
+
+Import-EnvFile -Path $EnvFile
+
+if (-not $env:HOMEASSISTANT_URL) {
+    if ($env:HASS_BASE_URL) {
+        $env:HOMEASSISTANT_URL = $env:HASS_BASE_URL
+    }
+    else {
+        throw "HOMEASSISTANT_URL is missing from $EnvFile"
+    }
+}
+
+if (-not $env:HOMEASSISTANT_TOKEN) {
+    if ($env:HASS_TOKEN) {
+        $env:HOMEASSISTANT_TOKEN = $env:HASS_TOKEN
+    }
+    else {
+        throw "HOMEASSISTANT_TOKEN is missing from $EnvFile"
+    }
+}
+
+$env:HOMEASSISTANT_URL = $env:HOMEASSISTANT_URL.TrimEnd('/')
+
+if (-not $env:FASTMCP_SHOW_SERVER_BANNER) {
+    $env:FASTMCP_SHOW_SERVER_BANNER = "false"
+}
+
+$uvx = Get-Command uvx -ErrorAction SilentlyContinue
+if (-not $uvx) {
+    throw "uvx was not found on PATH. Install uv from https://docs.astral.sh/uv/getting-started/installation/ and restart VS Code."
+}
+
+& $uvx.Source --python 3.13 --refresh ha-mcp@latest
+exit $LASTEXITCODE


### PR DESCRIPTION
## Summary
- add per-load cumulative energy sensors in kWh for Home Assistant Energy dashboard support
- keep the related sensor and DMX integration cleanup changes on a dedicated feature branch
- merge the branch cleanly on top of the current `main`, including conflict resolution in `.gitignore`, `switch.py`, and `utils.py`

## Validation
- compiled the touched integration files with the workspace Python environment after the rebase
- verified the feature branch rebased cleanly onto the updated `main`

## Notes
- local `main` was first fast-forwarded to `origin/main`
- the feature branch was then rebased and pushed as `feature/individual-load-energy-dashboard`